### PR TITLE
support inline visibility modifiers

### DIFF
--- a/lib/syntax_tree/rbs/members.rb
+++ b/lib/syntax_tree/rbs/members.rb
@@ -16,6 +16,10 @@ module SyntaxTree
 
       def format(q)
         q.group do
+          if node.respond_to?(:visibility) && node.visibility
+            q.text("#{node.visibility} ")
+          end
+
           q.text("attr_#{type} ")
           q.text("self.") if node.kind == :singleton
           q.text(node.name)
@@ -42,6 +46,12 @@ module SyntaxTree
         q.breakable
         q.text("name=")
         q.pp(node.name)
+
+        if node.respond_to?(:visibility) && node.visibility
+          q.breakable
+          q.text("visibility=")
+          q.pp(node.visibility)
+        end
 
         unless node.ivar_name.nil?
           q.breakable
@@ -281,6 +291,10 @@ module RBS
           SyntaxTree::RBS::Annotations.maybe_format(q, annotations)
 
           q.group do
+            if respond_to?(:visibility) && visibility
+              q.text("#{visibility} ")
+            end
+
             q.text("def ")
 
             if kind == :singleton
@@ -331,6 +345,12 @@ module RBS
             q.breakable
             q.text("name=")
             q.pp(name)
+
+            if respond_to?(:visibility) && visibility
+              q.breakable
+              q.text("visibility=")
+              q.pp(visibility)
+            end
 
             if overload?
               q.breakable

--- a/test/fixtures/member.txt
+++ b/test/fixtures/member.txt
@@ -26,3 +26,7 @@ prepend Foo
 extend Foo
 private
 public
+private attr_accessor foo: Foo
+private attr_accessor foo(@bar): Foo
+public attr_accessor foo(): Foo
+public attr_writer self.foo(@bar): Foo

--- a/test/fixtures/method.txt
+++ b/test/fixtures/method.txt
@@ -15,3 +15,7 @@ def t: ?{ -> void } -> void
 def `self`: -> void
 def `: -> void
 def t: (untyped `untyped`) -> void
+private def t: -> ("a" | "b" | "c")
+private def self.t: -> void | ...
+public def t: -> ("a" & ("b" | "c"))?
+public def t: (untyped `untyped`) -> void

--- a/test/rbs_test.rb
+++ b/test/rbs_test.rb
@@ -85,7 +85,9 @@ class RBSTest < Minitest::Test
     "include Foo",
     "@foo: String",
     "def t: (T t) -> void",
-    "prepend Foo"
+    "prepend Foo",
+    "private def t: (T t) -> void",
+    "public attr_accessor foo: Foo",
   ]
 
   test_fixtures("members_with_comments", fixtures) do |fixture|
@@ -127,7 +129,9 @@ class RBSTest < Minitest::Test
     "extend Foo",
     "include Foo",
     "def t: (T t) -> void",
-    "prepend Foo"
+    "prepend Foo",
+    "private def t: (T t) -> void",
+    "public attr_accessor foo: Foo",
   ]
 
   test_fixtures("members_with_annotations", fixtures) do |fixture|


### PR DESCRIPTION
Support formatting rbs files with inline visibility modifiers per https://github.com/prettier/plugin-ruby/pull/1173#issuecomment-1091684815