### PR TITLE
Support Ruby 2.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-        - '2.7.5'
+        - '2.7.0'
         - '3.0'
         - '3.1'
         gemfile:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- Ruby 2.7.0 is now supported, not just 2.7.3 and above. This allows usage on Ubuntu 20.04 by default.
+
 ## [0.5.0] - 2022-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.1]
 
-### Added
+### Added - 2022-09-03
 
 - Ruby 2.7.0 is now supported, not just 2.7.3 and above. This allows usage on Ubuntu 20.04 by default.
 
@@ -46,7 +46,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - 🎉 Initial release! 🎉
 
-[unreleased]: https://github.com/ruby-syntax-tree/syntax_tree-rbs/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/ruby-syntax-tree/syntax_tree-rbs/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/ruby-syntax-tree/syntax_tree-rbs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ruby-syntax-tree/syntax_tree-rbs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ruby-syntax-tree/syntax_tree-rbs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ruby-syntax-tree/syntax_tree-rbs/compare/v0.2.0...v0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    syntax_tree-rbs (0.5.0)
+    syntax_tree-rbs (0.5.1)
       prettier_print
       rbs
       syntax_tree (>= 2.0.1)

--- a/lib/syntax_tree/rbs.rb
+++ b/lib/syntax_tree/rbs.rb
@@ -24,8 +24,8 @@ module SyntaxTree
     class Formatter < PrettierPrint
       attr_reader :source
 
-      def initialize(source, ...)
-        super(...)
+      def initialize(source, *, **)
+        super
         @source = source
         @force_parens = false
       end

--- a/lib/syntax_tree/rbs.rb
+++ b/lib/syntax_tree/rbs.rb
@@ -24,8 +24,8 @@ module SyntaxTree
     class Formatter < PrettierPrint
       attr_reader :source
 
-      def initialize(source, *, **)
-        super
+      def initialize(source, *rest)
+        super(*rest)
         @source = source
         @force_parens = false
       end

--- a/lib/syntax_tree/rbs/version.rb
+++ b/lib/syntax_tree/rbs/version.rb
@@ -2,6 +2,6 @@
 
 module SyntaxTree
   module RBS
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
Similar to https://github.com/ruby-syntax-tree/syntax_tree/issues/144, this package is also a dependency of running Prettier for Ruby code on Ubuntu 20.04.

Since @kddnewton was kind enough to add Ruby 2.7.0 support to syntax_tree proper in https://github.com/ruby-syntax-tree/syntax_tree/pull/148, I figured I would try to update syntax_tree-rbs myself. Unfortunately, having little experience with Ruby, my work has proceeded very slowly. I get these errors when running the tests under 2.7.0:

```
186) Error:
RBSTest#test_class:
FrozenError: can't modify frozen String: "class Foo\nend\n"
    /home/raxod502/files/code/lib/syntax_tree-rbs/.bundle/vendor/ruby/2.7.0/gems/prettier_print-0.1.0/lib/prettier_print.rb:274:in `<<'
    /home/raxod502/files/code/lib/syntax_tree-rbs/.bundle/vendor/ruby/2.7.0/gems/prettier_print-0.1.0/lib/prettier_print.rb:761:in `block in flush'
    /home/raxod502/files/code/lib/syntax_tree-rbs/.bundle/vendor/ruby/2.7.0/gems/prettier_print-0.1.0/lib/prettier_print.rb:761:in `each'
    /home/raxod502/files/code/lib/syntax_tree-rbs/.bundle/vendor/ruby/2.7.0/gems/prettier_print-0.1.0/lib/prettier_print.rb:761:in `flush'
    /home/raxod502/files/code/lib/syntax_tree-rbs/lib/syntax_tree/rbs.rb:51:in `format'
    /home/raxod502/files/code/lib/syntax_tree-rbs/test/rbs_test.rb:343:in `assert_format'
    /home/raxod502/files/code/lib/syntax_tree-rbs/test/rbs_test.rb:163:in `test_class'

187) Error:
RBSTest#test_interface_5:
TypeError: no implicit conversion of Integer into Array
    /home/raxod502/files/code/lib/syntax_tree-rbs/.bundle/vendor/ruby/2.7.0/gems/prettier_print-0.1.0/lib/prettier_print.rb:782:in `-'
    /home/raxod502/files/code/lib/syntax_tree-rbs/.bundle/vendor/ruby/2.7.0/gems/prettier_print-0.1.0/lib/prettier_print.rb:782:in `flush'
    /home/raxod502/files/code/lib/syntax_tree-rbs/lib/syntax_tree/rbs.rb:51:in `format'
    /home/raxod502/files/code/lib/syntax_tree-rbs/test/rbs_test.rb:343:in `assert_format'
    /home/raxod502/files/code/lib/syntax_tree-rbs/test/rbs_test.rb:16:in `block (2 levels) in test_fixtures'
```

For some reason, the pretty-printing library seems like it's trying to modify one of the string literals that gets passed in from the test fixtures in syntax_tree-rbs, and I haven't been able to figure out why that's happening yet. The tests for prettier_print pass under 2.7.0, so I figure it isn't a problem within that library (or at least it's a bug that isn't known yet).

I'll continue working on this when I have time, but if anyone more familiar with Ruby wants to take a look, it'd probably speed things up.