### PR TITLE
fix: allow "syntax_tree-rbs" to be used in "stree write --plugin=rbs"

### DIFF
--- a/lib/syntax_tree/rbs.rb
+++ b/lib/syntax_tree/rbs.rb
@@ -41,7 +41,7 @@ module SyntaxTree
     end
 
     class << self
-      def format(source, maxwidth = 80)
+      def format(source, maxwidth = 80, _options = {})
         formatter = Formatter.new(source, [], maxwidth)
         parse(source).format(formatter)
 


### PR DESCRIPTION
# Error

```
wrong number of arguments (given 3, expected 1..2)
/root/.local/asdf/installs/ruby/3.2.6/lib/ruby/gems/3.2.0/gems/syntax_tree-rbs-1.0.0/lib/syntax_tree/rbs.rb:44:in `format'
/root/.local/asdf/installs/ruby/3.2.6/lib/ruby/gems/3.2.0/gems/syntax_tree-6.2.0/lib/syntax_tree/cli.rb:388:in `run'
/root/.local/asdf/installs/ruby/3.2.6/lib/ruby/gems/3.2.0/gems/syntax_tree-6.2.0/lib/syntax_tree/cli.rb:671:in `block (2 levels) in process_queue'
```

---

# Replication

```ruby
gem "syntax_tree"
gem "syntax_tree-rbs"
```

```bash
bundle exec stree write -- "..."
```

---

See https://github.com/anthropics/anthropic-sdk-ruby/blob/b6fd5e4a006c0720e5256fdece4943e45bb789c8/Gemfile#L15

